### PR TITLE
feat(showcase): add uPortal-home and app framework

### DIFF
--- a/index.md
+++ b/index.md
@@ -153,7 +153,7 @@ folks contributing to:
 * [istanbuljs](https://github.com/istanbuljs/istanbuljs): a collection of open-source tools
   and libraries for adding test coverage to your JavaScript tests.
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
-* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame)
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame): Optional supplemental user interface enhancing [Apereo uPortal](https://www.apereo.org/projects/uportal).
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 

--- a/index.md
+++ b/index.md
@@ -153,6 +153,7 @@ folks contributing to:
 * [istanbuljs](https://github.com/istanbuljs/istanbuljs): a collection of open-source tools
   and libraries for adding test coverage to your JavaScript tests.
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame)
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
`uPortal-home` (previously known as `AngularJS-portal`) and `uPortal-application-framework` (previously known as `uw-frame`) have both adopted Conventional Commits.

+ uPortal-home in its [PR 666](https://github.com/UW-Madison-DoIT/angularjs-portal/pull/666)
+ uPortal-application-framework in its [PR 487](https://github.com/UW-Madison-DoIT/uw-frame/pull/487)