### PR TITLE
fix(example): present tense imperative. "adds ability" -> "add ability".

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ consumers of your library:
 
 <br />
 A scope may be provided to a commit's type, to provide additional contextual information and
-is contained within parenthesis, e.g., `feat(parser): adds ability to parse arrays`.
+is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
 
 Commit _types_ other than `fix:` and `feat:` are allowed, for example [the Angular convention](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) recommends `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, but these tags are
 not mandated by the conventional commits specification.


### PR DESCRIPTION
Use the present tense imperative mood in the example commit message. 

So, `feat(parser): add ability to parse arrays` , not `feat(parser): adds ability to parse arrays`.

Conventional Commits may not need to specify present tense, imperative mood for verbs. But I think at least the example should use the common present tense, imperative mood practice.

Maybe Conventional Commits should specify. Makes for a stronger convention.

References:
+ [Commit Verbs 101: why I like to use this and why you should also like it.][]: "Always use the verbs in Imperative Present tense. Don’t use Past or Present Continuous tenses for commits."
+ [Git book on commit message recommendations][]: "It’s also a good idea to use the imperative present tense in these messages. In other words, use commands. Instead of `I added tests for` or `Adding tests for,` use `Add tests for.`"
+ [How to Write a Git Commit Message][]: "Use the imperative mood in the subject line"


[
Commit Verbs 101: why I like to use this and why you should also like it.]: https://medium.com/@danielfeelfine/commit-verbs-101-why-i-like-to-use-this-and-why-you-should-also-like-it-d3ed2689ef70
[Git book on commit message recommendations]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project
[How to Write a Git Commit Message]: https://chris.beams.io/posts/git-commit/