### PR TITLE
feat(lang): add zh-Hans translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ languages:
   en: english
   pl: polish
   it: italian
+  zh-Hans: 简体中文
 
 versions:
   - 1.0.0-beta

--- a/lang/zh-Hans/index.md
+++ b/lang/zh-Hans/index.md
@@ -1,0 +1,133 @@
+---
+title: 约定式提交 1.0.0-beta.1
+language: zh-Hans
+---
+
+# 约定式提交 1.0.0-beta.1
+
+## 概述
+
+开源维护者在将特性分支合并入 `master` 时，可编写标准化的提交说明。
+
+提交说明的结构如下所示：
+
+---
+
+```
+<类型>[可选的作用域]: <描述>
+
+[可选的正文]
+
+[可选的页脚]
+```
+---
+
+<br />
+提交说明包含了下面的结构化元素，以向类库使用者表明其意图：
+
+1. **fix:** _类型_ 为 `fix` 的提交表示在代码库中修复了一个 bug（这和语义化版本中的 [`PATCH`](http://semver.org/#summary) 相对应）。
+2. **feat:** _类型_ 为 `feat` 的提交表示在代码库中新增了一个功能（这和语义化版本中的 [`MINOR`](http://semver.org/#summary) 相对应）。
+3. **BREAKING CHANGE:** 在可选的正文或页脚的起始位置带有 `BREAKING CHANGE:` 的提交，表示引入了破坏性变更（这和语义化版本中的 [`MAJOR`](http://semver.org/#summary) 相对应）。破坏性变更可以是任意 _类型_ 提交的一部分。对于 `fix:`、`feat:` 和 `chore:`，乃至更多其它的 _类型_ 而言，它都是有效的。
+4. 其它在 `fix:` 和 `feat:` 之外的提交 _类型_ 也都是支持的，例如 [Angular 约定](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) 中推荐使用 `docs:`、`style:`、`refactor:`、`perf:`、`test:`、`chore:`，但这些标签在约定式提交规范中并不是强制性的。
+
+<br />
+可以为提交类型添加一个围在圆括号内的作用域，以为其提供额外的上下文信息。例如，`feat(parser): add ability to parse arrays`。
+
+## 介绍
+
+在软件开发中，个人的经验是 bug 最常由应用间的边界引入。对单元测试而言，在所测试的交互处在开源维护者知识范围内时，它工作得很好。但在刻画社区里各种有趣而常在预料之外的使用场景时，它就显得比较糟糕了。
+
+任何在升级新依赖 patch 版本后发现应用开始抛出稳定 500 错误流的人，都知道可读的提交历史（以及[理想条件下高质量维护的 CHANGELOG](http://keepachangelog.com/en/0.3.0/)）有多重要。
+
+约定式的提交规范提议在提交说明的基础上，引入标准化的轻量约定。这个约定和 [SemVer](http://semver.org) 相吻合，要求开发者在提交信息中描述新特性、bug 修复和破坏性更新。
+
+引入这一约定后，我们可以创建一种通用的语言，简化在项目边界之间调试的问题。
+
+## 约定式提交规范
+
+本文档中的关键词 “必须”，“禁止”，“需要”，“应当”，“不应当”，“应该”，“不应该”，“推荐”，“可以” 和 “可选” 应按照 [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) 的描述解释。
+
+1. 每个提交都**必须**使用类型字段前缀，这由一个形如 `feat` 或 `fix` 的动词组成，其后接冒号和空格。
+2. 当一个提交为应用或类库实现了新特性时，**必须**使用 `feat` 类型。
+3. 当一个提交为应用修复了 bug 时，**必须**使用 `fix` 类型。
+4. 可选的作用域字段**可以**在类型后提供。作用域是描述代码库中某个部分的词组，封装在括号中，形如 `fix(parser):` 等。
+5. 描述字段**必须**紧接在类型或作用域前缀之后。描述指的是对 pull request 的简短描述，形如：_fix: array parsing issue when multiple spaces were contained in string._
+6. 在简短描述之后，**可以**编写更长的提交正文。正文**必须**起始于描述字段结束的一个空行后。
+7. 在正文结束的一个空行后，**可以**编写页脚。页脚**应当**包含额外的元信息（例如它所修复的 issue，类似 `fixse #13, #5` 等）。
+8. 破坏性变更**必须**在提交的正文或脚注加以展示。一个破坏性变更**必须**包含大写的文本 `BREAKING CHANGE`，紧跟冒号和空格。
+9. 在 `BREAKING CHANGE: ` 之后**必须**提供描述，以描述对 API 的变更。例如 _BREAKING CHANGE: environment variables now take precedence over config files._
+10. 在提交说明中，**可以**使用 `feat` 和 `fix` 之外的类型。
+
+## 为什么使用约定式提交
+
+* 自动化生成 CHANGELOG。
+* 基于提交的类型，自动决定语义化的版本变更。
+* 向同事、公众与其他利益关系人传达变化的性质。
+* 触发构建和部署流程。
+* 让人们更容易地探索结构化的提交历史，降低贡献项目的难度。
+
+## FAQ
+
+### 如何处理初始开发阶段的提交说明？
+
+我们建议你按照已发布的产品那样来处理。一般情况下即便是开发者同事，也*有人*使用你的软件。他们会希望知道诸如修复了什么、哪里不兼容等信息。
+
+### 提交符合一或多种类型时该如何处理？
+
+回退并尽可能创建多次提交。约定式提交的部分好处是能够促使我们做出更有组织的提交和 PR。
+
+### 这不会阻碍快速的开发和迭代吗？
+
+它阻碍的是以杂乱无章的方式快速前进。它帮助我们在横跨长时间周期、多个项目、多个贡献者时能够保持效率。
+
+### 约定式提交会让开发者受限于提交的类型吗？
+
+约定式提交鼓励我们更多地使用某些类型的提交，比如 fixes。除此之外，约定式提交的灵活性也允许你的团队使用自己的类型，并随着时间的推移更改这些类型。
+
+### 这和 SemVer 有什么关联呢？
+
+`fix` 类型提交应当对应到 `PATCH` 版本。`feat` 类型提交应该对应到 `MINOR` 版本。带有 `BREAKING CHANGE` 的提交不管类型如何，都应该对应到 `MAJOR` 版本。
+
+### 我对约定式提交做了形如 `@jameswomack/conventional-commit-spec` 的扩展，该如何版本化管理这些扩展呢？
+
+我们推荐使用 SemVer 来发布你对于这个规范的扩展（并鼓励你创建这些扩展！）
+
+### 如果我不小心使用了错误的提交类型，该怎么办呢？
+
+#### 当你使用了在规范中但错误的类型时，如将 `feat` 写成了 `fix`
+
+在合并或发布这个错误之前，我们建议使用 `git rebase -i` 来编辑提交历史。而在发布之后，根据你使用的工具和流程不同，会有不同的清理方案。
+
+#### 当使用了*不*在规范中的类型时，如将 `feat` 写成了 `feet`
+
+在最坏的场景下，即便提交没有满足约定式提交的规范，也不是世界的终结。这只意味着这个提交会被基于规范的工具错过而已。
+
+### 所有的贡献者都需要使用约定式提交规范吗？
+
+并不！如果你使用基于 squash 的 Git 工作流，主管维护者可以在合并时清理提交信息——这不会对普通提交者产生额外的负担。有种常见的工作流是让 git 系统自动从 pull request 中 squash 出提交，向主管维护者提供表单，来在合并时输入合适的 git 提交信息。
+
+## 关于
+
+约定式提交规范受到了 [Angular 提交准则](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)的启发，并在很大程度上以其为依据。
+
+该规范的首个草案来自下面这些项目中若干贡献者们的协作：
+
+
+* [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)：一套从 git 历史中解析出约定式提交说明的工具。
+* [unleash](https://github.com/netflix/unleash)：一个用于自动化软件发行和发布生命周期的工具。
+* [lerna](https://github.com/lerna/lerna)：一个用于管理宏仓库的工具，源自 Babel 项目。
+
+## 使用约定式提交的项目
+
+* [yargs](https://github.com/yargs/yargs)：广受欢迎的命令行参数解析器。
+* [istanbuljs](https://github.com/istanbuljs/istanbuljs)：一套为 JavaScript 测试生成测试覆盖率的开源工具和类库。
+* [standard-version](https://github.com/conventional-changelog/standard-version) 基于 GitHub 的新 squash 按钮与推荐的约定式提交工作流，自动管理版本和 CHANGELOG。
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) 和 [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame)：用于增强 [Apereo uPortal](https://www.apereo.org/projects/uportal) 的可选用户界面。
+
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+_想让你的项目出现在上面吗？_[提交 pull request](https://github.com/conventional-changelog/conventionalcommits.org/pulls) 吧。
+
+## 许可
+
+[Creative Commons - CC BY 3.0](http://creativecommons.org/licenses/by/3.0/)

--- a/lang/zh-Hans/spec/v1.0.0-beta.1.md
+++ b/lang/zh-Hans/spec/v1.0.0-beta.1.md
@@ -1,0 +1,133 @@
+---
+title: 约定式提交 1.0.0-beta.1
+language: zh-Hans
+---
+
+# 约定式提交 1.0.0-beta.1
+
+## 概述
+
+开源维护者在将特性分支合并入 `master` 时，可编写标准化的提交说明。
+
+提交说明的结构如下所示：
+
+---
+
+```
+<类型>[可选的作用域]: <描述>
+
+[可选的正文]
+
+[可选的页脚]
+```
+---
+
+<br />
+提交说明包含了下面的结构化元素，以向类库使用者表明其意图：
+
+1. **fix:** _类型_ 为 `fix` 的提交表示在代码库中修复了一个 bug（这和语义化版本中的 [`PATCH`](http://semver.org/#summary) 相对应）。
+2. **feat:** _类型_ 为 `feat` 的提交表示在代码库中新增了一个功能（这和语义化版本中的 [`MINOR`](http://semver.org/#summary) 相对应）。
+3. **BREAKING CHANGE:** 在可选的正文或页脚的起始位置带有 `BREAKING CHANGE:` 的提交，表示引入了破坏性变更（这和语义化版本中的 [`MAJOR`](http://semver.org/#summary) 相对应）。破坏性变更可以是任意 _类型_ 提交的一部分。对于 `fix:`、`feat:` 和 `chore:`，乃至更多其它的 _类型_ 而言，它都是有效的。
+4. 其它在 `fix:` 和 `feat:` 之外的提交 _类型_ 也都是支持的，例如 [Angular 约定](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) 中推荐使用 `docs:`、`style:`、`refactor:`、`perf:`、`test:`、`chore:`，但这些标签在约定式提交规范中并不是强制性的。
+
+<br />
+可以为提交类型添加一个围在圆括号内的作用域，以为其提供额外的上下文信息。例如，`feat(parser): add ability to parse arrays`。
+
+## 介绍
+
+在软件开发中，个人的经验是 bug 最常由应用间的边界引入。对单元测试而言，在所测试的交互处在开源维护者知识范围内时，它工作得很好。但在刻画社区里各种有趣而常在预料之外的使用场景时，它就显得比较糟糕了。
+
+任何在升级新依赖 patch 版本后发现应用开始抛出稳定 500 错误流的人，都知道可读的提交历史（以及[理想条件下高质量维护的 CHANGELOG](http://keepachangelog.com/en/0.3.0/)）有多重要。
+
+约定式的提交规范提议在提交说明的基础上，引入标准化的轻量约定。这个约定和 [SemVer](http://semver.org) 相吻合，要求开发者在提交信息中描述新特性、bug 修复和破坏性更新。
+
+引入这一约定后，我们可以创建一种通用的语言，简化在项目边界之间调试的问题。
+
+## 约定式提交规范
+
+本文档中的关键词 “必须”，“禁止”，“需要”，“应当”，“不应当”，“应该”，“不应该”，“推荐”，“可以” 和 “可选” 应按照 [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) 的描述解释。
+
+1. 每个提交都**必须**使用类型字段前缀，这由一个形如 `feat` 或 `fix` 的动词组成，其后接冒号和空格。
+2. 当一个提交为应用或类库实现了新特性时，**必须**使用 `feat` 类型。
+3. 当一个提交为应用修复了 bug 时，**必须**使用 `fix` 类型。
+4. 可选的作用域字段**可以**在类型后提供。作用域是描述代码库中某个部分的词组，封装在括号中，形如 `fix(parser):` 等。
+5. 描述字段**必须**紧接在类型或作用域前缀之后。描述指的是对 pull request 的简短描述，形如：_fix: array parsing issue when multiple spaces were contained in string._
+6. 在简短描述之后，**可以**编写更长的提交正文。正文**必须**起始于描述字段结束的一个空行后。
+7. 在正文结束的一个空行后，**可以**编写页脚。页脚**应当**包含额外的元信息（例如它所修复的 issue，类似 `fixse #13, #5` 等）。
+8. 破坏性变更**必须**在提交的正文或脚注加以展示。一个破坏性变更**必须**包含大写的文本 `BREAKING CHANGE`，紧跟冒号和空格。
+9. 在 `BREAKING CHANGE: ` 之后**必须**提供描述，以描述对 API 的变更。例如 _BREAKING CHANGE: environment variables now take precedence over config files._
+10. 在提交说明中，**可以**使用 `feat` 和 `fix` 之外的类型。
+
+## 为什么使用约定式提交
+
+* 自动化生成 CHANGELOG。
+* 基于提交的类型，自动决定语义化的版本变更。
+* 向同事、公众与其他利益关系人传达变化的性质。
+* 触发构建和部署流程。
+* 让人们更容易地探索结构化的提交历史，降低贡献项目的难度。
+
+## FAQ
+
+### 如何处理初始开发阶段的提交说明？
+
+我们建议你按照已发布的产品那样来处理。一般情况下即便是开发者同事，也*有人*使用你的软件。他们会希望知道诸如修复了什么、哪里不兼容等信息。
+
+### 提交符合一或多种类型时该如何处理？
+
+回退并尽可能创建多次提交。约定式提交的部分好处是能够促使我们做出更有组织的提交和 PR。
+
+### 这不会阻碍快速的开发和迭代吗？
+
+它阻碍的是以杂乱无章的方式快速前进。它帮助我们在横跨长时间周期、多个项目、多个贡献者时能够保持效率。
+
+### 约定式提交会让开发者受限于提交的类型吗？
+
+约定式提交鼓励我们更多地使用某些类型的提交，比如 fixes。除此之外，约定式提交的灵活性也允许你的团队使用自己的类型，并随着时间的推移更改这些类型。
+
+### 这和 SemVer 有什么关联呢？
+
+`fix` 类型提交应当对应到 `PATCH` 版本。`feat` 类型提交应该对应到 `MINOR` 版本。带有 `BREAKING CHANGE` 的提交不管类型如何，都应该对应到 `MAJOR` 版本。
+
+### 我对约定式提交做了形如 `@jameswomack/conventional-commit-spec` 的扩展，该如何版本化管理这些扩展呢？
+
+我们推荐使用 SemVer 来发布你对于这个规范的扩展（并鼓励你创建这些扩展！）
+
+### 如果我不小心使用了错误的提交类型，该怎么办呢？
+
+#### 当你使用了在规范中但错误的类型时，如将 `feat` 写成了 `fix`
+
+在合并或发布这个错误之前，我们建议使用 `git rebase -i` 来编辑提交历史。而在发布之后，根据你使用的工具和流程不同，会有不同的清理方案。
+
+#### 当使用了*不*在规范中的类型时，如将 `feat` 写成了 `feet`
+
+在最坏的场景下，即便提交没有满足约定式提交的规范，也不是世界的终结。这只意味着这个提交会被基于规范的工具错过而已。
+
+### 所有的贡献者都需要使用约定式提交规范吗？
+
+并不！如果你使用基于 squash 的 Git 工作流，主管维护者可以在合并时清理提交信息——这不会对普通提交者产生额外的负担。有种常见的工作流是让 git 系统自动从 pull request 中 squash 出提交，向主管维护者提供表单，来在合并时输入合适的 git 提交信息。
+
+## 关于
+
+约定式提交规范受到了 [Angular 提交准则](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)的启发，并在很大程度上以其为依据。
+
+该规范的首个草案来自下面这些项目中若干贡献者们的协作：
+
+
+* [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)：一套从 git 历史中解析出约定式提交说明的工具。
+* [unleash](https://github.com/netflix/unleash)：一个用于自动化软件发行和发布生命周期的工具。
+* [lerna](https://github.com/lerna/lerna)：一个用于管理宏仓库的工具，源自 Babel 项目。
+
+## 使用约定式提交的项目
+
+* [yargs](https://github.com/yargs/yargs)：广受欢迎的命令行参数解析器。
+* [istanbuljs](https://github.com/istanbuljs/istanbuljs)：一套为 JavaScript 测试生成测试覆盖率的开源工具和类库。
+* [standard-version](https://github.com/conventional-changelog/standard-version) 基于 GitHub 的新 squash 按钮与推荐的约定式提交工作流，自动管理版本和 CHANGELOG。
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) 和 [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame)：用于增强 [Apereo uPortal](https://www.apereo.org/projects/uportal) 的可选用户界面。
+
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+_想让你的项目出现在上面吗？_[提交 pull request](https://github.com/conventional-changelog/conventionalcommits.org/pulls) 吧。
+
+## 许可
+
+[Creative Commons - CC BY 3.0](http://creativecommons.org/licenses/by/3.0/)

--- a/lang/zh-Hans/spec/v1.0.0-beta.md
+++ b/lang/zh-Hans/spec/v1.0.0-beta.md
@@ -1,0 +1,133 @@
+---
+title: 约定式提交 1.0.0-beta
+language: zh-Hans
+---
+
+# 约定式提交 1.0.0-beta
+
+## 概述
+
+开源维护者在将特性分支合并入 `master` 时，可编写标准化的提交说明。
+
+提交说明的结构如下所示：
+
+---
+
+```
+<类型>[可选的作用域]: <描述>
+
+[可选的正文]
+
+[可选的页脚]
+```
+---
+
+<br />
+提交说明包含了下面的结构化元素，以向类库使用者表明其意图：
+
+1. **fix:** _类型_ 为 `fix` 的提交表示在代码库中修复了一个 bug（这和语义化版本中的 [`PATCH`](http://semver.org/#summary) 相对应）。
+2. **feat:** _类型_ 为 `feat` 的提交表示在代码库中新增了一个功能（这和语义化版本中的 [`MINOR`](http://semver.org/#summary) 相对应）。
+3. **BREAKING CHANGE:** 在可选的正文或页脚的起始位置带有 `BREAKING CHANGE:` 的提交，表示引入了破坏性变更（这和语义化版本中的 [`MAJOR`](http://semver.org/#summary) 相对应）。破坏性变更可以是 `fix:` 或 `feat:` _类型_ 提交的一部分。
+4. 其它在 `fix:` 和 `feat:` 之外的提交 _类型_ 也都是支持的，例如 [Angular 约定](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit) 中推荐使用 `docs:`、`style:`、`refactor:`、`perf:`、`test:`、`chore:`，但这些标签在约定式提交规范中并不是强制性的。
+
+<br />
+可以为提交类型添加一个围在圆括号内的作用域，以为其提供额外的上下文信息。例如，`feat(parser): add ability to parse arrays`。
+
+## 介绍
+
+在软件开发中，个人的经验是 bug 最常由应用间的边界引入。对单元测试而言，在所测试的交互处在开源维护者知识范围内时，它工作得很好。但在刻画社区里各种有趣而常在预料之外的使用场景时，它就显得比较糟糕了。
+
+任何在升级新依赖 patch 版本后发现应用开始抛出稳定 500 错误流的人，都知道可读的提交历史（以及[理想条件下高质量维护的 CHANGELOG](http://keepachangelog.com/en/0.3.0/)）有多重要。
+
+约定式的提交规范提议在提交说明的基础上，引入标准化的轻量约定。这个约定和 [SemVer](http://semver.org) 相吻合，要求开发者在提交信息中描述新特性、bug 修复和破坏性更新。
+
+引入这一约定后，我们可以创建一种通用的语言，简化在项目边界之间调试的问题。
+
+## 约定式提交规范
+
+本文档中的关键词 “必须”，“禁止”，“需要”，“应当”，“不应当”，“应该”，“不应该”，“推荐”，“可以” 和 “可选” 应按照 [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) 的描述解释。
+
+1. 每个提交都**必须**使用类型字段前缀，这由一个形如 `feat` 或 `fix` 的动词组成，其后接冒号和空格。
+2. 当一个提交为应用或类库实现了新特性时，**必须**使用 `feat` 类型。
+3. 当一个提交为应用修复了 bug 时，**必须**使用 `fix` 类型。
+4. 可选的作用域字段**可以**在类型后提供。作用域是描述代码库中某个部分的词组，封装在括号中，形如 `fix(parser):` 等。
+5. 描述字段**必须**紧接在类型或作用域前缀之后。描述指的是对 pull request 的简短描述，形如：_fix: array parsing issue when multiple spaces were contained in string._
+6. 在简短描述之后，**可以**编写更长的提交正文。正文**必须**起始于描述字段结束的一个空行后。
+7. 在正文结束的一个空行后，**可以**编写页脚。页脚**应当**包含额外的元信息（例如它所修复的 issue，类似 `fixse #13, #5` 等）。
+8. 破坏性变更**必须**在提交的正文或脚注加以展示。一个破坏性变更**必须**包含大写的文本 `BREAKING CHANGE`，紧跟冒号和空格。
+9. 在 `BREAKING CHANGE: ` 之后**必须**提供描述，以描述对 API 的变更。例如 _BREAKING CHANGE: environment variables now take precedence over config files._
+10. 在提交说明中，**可以**使用 `feat` 和 `fix` 之外的类型。
+
+## 为什么使用约定式提交
+
+* 自动化生成 CHANGELOG。
+* 基于提交的类型，自动决定语义化的版本变更。
+* 向同事、公众与其他利益关系人传达变化的性质。
+* 触发构建和部署流程。
+* 让人们更容易地探索结构化的提交历史，降低贡献项目的难度。
+
+## FAQ
+
+### 如何处理初始开发阶段的提交说明？
+
+我们建议你按照已发布的产品那样来处理。一般情况下即便是开发者同事，也*有人*使用你的软件。他们会希望知道诸如修复了什么、哪里不兼容等信息。
+
+### 提交符合一或多种类型时该如何处理？
+
+回退并尽可能创建多次提交。约定式提交的部分好处是能够促使我们做出更有组织的提交和 PR。
+
+### 这不会阻碍快速的开发和迭代吗？
+
+它阻碍的是以杂乱无章的方式快速前进。它帮助我们在横跨长时间周期、多个项目、多个贡献者时能够保持效率。
+
+### 约定式提交会让开发者受限于提交的类型吗？
+
+约定式提交鼓励我们更多地使用某些类型的提交，比如 fixes。除此之外，约定式提交的灵活性也允许你的团队使用自己的类型，并随着时间的推移更改这些类型。
+
+### 这和 SemVer 有什么关联呢？
+
+`fix` 类型提交应当对应到 `PATCH` 版本。`feat` 类型提交应该对应到 `MINOR` 版本。带有 `BREAKING CHANGE` 的提交不管类型如何，都应该对应到 `MAJOR` 版本。
+
+### 我对约定式提交做了形如 `@jameswomack/conventional-commit-spec` 的扩展，该如何版本化管理这些扩展呢？
+
+我们推荐使用 SemVer 来发布你对于这个规范的扩展（并鼓励你创建这些扩展！）
+
+### 如果我不小心使用了错误的提交类型，该怎么办呢？
+
+#### 当你使用了在规范中但错误的类型时，如将 `feat` 写成了 `fix`
+
+在合并或发布这个错误之前，我们建议使用 `git rebase -i` 来编辑提交历史。而在发布之后，根据你使用的工具和流程不同，会有不同的清理方案。
+
+#### 当使用了*不*在规范中的类型时，如将 `feat` 写成了 `feet`
+
+在最坏的场景下，即便提交没有满足约定式提交的规范，也不是世界的终结。这只意味着这个提交会被基于规范的工具错过而已。
+
+### 所有的贡献者都需要使用约定式提交规范吗？
+
+并不！如果你使用基于 squash 的 Git 工作流，主管维护者可以在合并时清理提交信息——这不会对普通提交者产生额外的负担。有种常见的工作流是让 git 系统自动从 pull request 中 squash 出提交，向主管维护者提供表单，来在合并时输入合适的 git 提交信息。
+
+## 关于
+
+约定式提交规范受到了 [Angular 提交准则](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit)的启发，并在很大程度上以其为依据。
+
+该规范的首个草案来自下面这些项目中若干贡献者们的协作：
+
+
+* [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)：一套从 git 历史中解析出约定式提交说明的工具。
+* [unleash](https://github.com/netflix/unleash)：一个用于自动化软件发行和发布生命周期的工具。
+* [lerna](https://github.com/lerna/lerna)：一个用于管理宏仓库的工具，源自 Babel 项目。
+
+## 使用约定式提交的项目
+
+* [yargs](https://github.com/yargs/yargs)：广受欢迎的命令行参数解析器。
+* [istanbuljs](https://github.com/istanbuljs/istanbuljs)：一套为 JavaScript 测试生成测试覆盖率的开源工具和类库。
+* [standard-version](https://github.com/conventional-changelog/standard-version) 基于 GitHub 的新 squash 按钮与推荐的约定式提交工作流，自动管理版本和 CHANGELOG。
+* [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) 和 [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame)：用于增强 [Apereo uPortal](https://www.apereo.org/projects/uportal) 的可选用户界面。
+
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
+_想让你的项目出现在上面吗？_[提交 pull request](https://github.com/conventional-changelog/conventionalcommits.org/pulls) 吧。
+
+## 许可
+
+[Creative Commons - CC BY 3.0](http://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
This PR adds simplified Chinese translation to Conventional Commits.

Some minor formats are modified to fit Chinese, e.g., since we don't have upper case and lower case in Chinese, bold format is used for translating `MUST`, `MAY`, etc.