### PR TITLE
FEAT: prescribe ALL-CAPS type when commit includes breaking change

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,8 @@ consumers of your library:
 2. **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in semantic versioning).
 3. **BREAKING CHANGE:** a commit that has the text `BREAKING CHANGE:` at the beginning of its optional body or footer section introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in semantic versioning).
 A breaking change can be part of commits of any _type_.
+When a commit contains a breaking change, the _type_ is in ALL CAPS to draw
+attention to this in the commit header.
 4. Others: commit _types_ other than `fix:` and `feat:` are allowed, for example [commitlint-config-conventional](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional) (based on the [the Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
 We also recommend `improvement` for commits that improve a current implementation without adding a new feature or fixing a bug.
 Notice these types are not mandated by the conventional commits specification, and have no implicit effect in semantic versioning (unless they include a BREAKING CHANGE, which is NOT recommended).
@@ -41,7 +43,7 @@ A scope may be provided to a commit's type, to provide additional contextual inf
 
 ### Commit message with description and breaking change in body
 ```
-feat: allow provided config object to extend other configs
+FEAT: allow provided config object to extend other configs
 
 BREAKING CHANGE: `extends` key in config file is now used for extending other config files
 ```
@@ -96,7 +98,7 @@ The description is a short description of the code changes, e.g., _fix: array pa
 6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
 7. A footer MAY be provided one blank line after the body (or after the description if body is missing).
   The footer SHOULD contain additional issue references about the code changes (such as the issues it fixes, e.g.,`Fixes #13`).
-8. Breaking changes MUST be indicated at the very beginning of the footer or body section of a commit. A breaking change MUST consist of the uppercase text `BREAKING CHANGE`, followed by a colon and a space.
+8. Breaking changes MUST be indicated at the very beginning of the footer or body section of a commit. A breaking change MUST consist of the uppercase text `BREAKING CHANGE`, followed by a colon and a space. Commits including a breaking change MUST also use ALL CAPS type.
 9. A description MUST be provided after the `BREAKING CHANGE: `, describing what has changed about the API, e.g., _BREAKING CHANGE: environment variables now take precedence over config files._
 10. The footer MUST only contain `BREAKING CHANGE`, external links, issue references, and other meta-information.
 11. Types other than `feat` and `fix` MAY be used in your commit messages.


### PR DESCRIPTION
BREAKING CHANGE: requires type in ALL-CAPS when the commit includes a breaking change, whereas previously type would always be lowercase. Tools enforcing Conventional Commits as understood prior to this change may flag or fail to correctly parse commit messages indicating breaking changes under this version of the spec.

When a commit includes a breaking change, surely this is the most important thing to say about that commit. So lead with it. Indicating the breaking-change-ness of a commit it its header rather than just in its body and footer makes it easier to skim to, notice, and parse out (from abbreviated representations of the commit log) these changes.

-----

This is another way of getting at the indicate-breaking-changes-in-the-header problem that #43 is trying to solve with a sigil. It might be that the sigil solution is better. I'm not sure that ALL-CAPS-ing the _type:_ is the move to make here.

I do think *something* should be done to indicate the breakingness of changes in the header rather than only in the body or footer.