### PR TITLE
BREAK: feat: indicate breaking changes in header via "BREAK: " prefix

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,10 +27,14 @@ The commit message should be structured as follows:
 The commit contains the following structural elements, to communicate intent to the
 consumers of your library:
 
+1. **BREAK:** a commit with the prefix "BREAK: " before its type introduces a
+   breaking API change.
 1. **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in semantic versioning).
 2. **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in semantic versioning).
 3. **BREAKING CHANGE:** a commit that has the text `BREAKING CHANGE:` at the beginning of its optional body or footer section introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in semantic versioning).
 A breaking change can be part of commits of any _type_.
+A commit including "BREAKING CHANGE:" in its body or footer MUST also have the
+prefix "BREAK: " before its _type_ in its header.
 4. Others: commit _types_ other than `fix:` and `feat:` are allowed, for example [commitlint-config-conventional](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional) (based on the [the Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
 We also recommend `improvement` for commits that improve a current implementation without adding a new feature or fixing a bug.
 Notice these types are not mandated by the conventional commits specification, and have no implicit effect in semantic versioning (unless they include a BREAKING CHANGE, which is NOT recommended).
@@ -41,7 +45,7 @@ A scope may be provided to a commit's type, to provide additional contextual inf
 
 ### Commit message with description and breaking change in body
 ```
-feat: allow provided config object to extend other configs
+BREAK: feat: allow provided config object to extend other configs
 
 BREAKING CHANGE: `extends` key in config file is now used for extending other config files
 ```
@@ -87,6 +91,8 @@ debug issues across project boundaries.
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
+1. Commits including a breaking change MUST be prefixed with "BREAK: ", before
+   the type.
 1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by a colon and a space.
 2. The type `feat` MUST be used when a commit adds a new feature to your application or library.
 3. The type `fix` MUST be used when a commit represents a bug fix for your application.
@@ -96,6 +102,9 @@ The description is a short description of the code changes, e.g., _fix: array pa
 6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
 7. A footer MAY be provided one blank line after the body (or after the description if body is missing).
   The footer SHOULD contain additional issue references about the code changes (such as the issues it fixes, e.g.,`Fixes #13`).
+8. Breaking changes MUST be indicated at the very beginning of the header
+   section of a commit. A breaking change commit header MUST consist of the
+   uppercase text `BREAK`, followed by a colon and a space.
 8. Breaking changes MUST be indicated at the very beginning of the footer or body section of a commit. A breaking change MUST consist of the uppercase text `BREAKING CHANGE`, followed by a colon and a space.
 9. A description MUST be provided after the `BREAKING CHANGE: `, describing what has changed about the API, e.g., _BREAKING CHANGE: environment variables now take precedence over config files._
 10. The footer MUST only contain `BREAKING CHANGE`, external links, issue references, and other meta-information.


### PR DESCRIPTION
BREAKING CHANGE: adds new "BREAK: " prefix before type in header in commits including breaking API changes. Tools written to the spec before this feature may fail to parse or flag as non-compliant commit messages using this feature. Breaking change commit messages written to prior versions of this spec will not be compliant with versions of the spec with this change.

Tools can regain spec compliance by adding support for parsing the new "BREAK: " prefix.

For a commit that includes API-breaking changes, that fact is the most important thing to say about the commit, so lead with it in the commit message header. Indicating breakingness in the commit message header makes API breakages more apparent on skim in more contexts.
