### PR TITLE
docs: use imperative verb in example

### DIFF
--- a/index.md
+++ b/index.md
@@ -53,7 +53,7 @@ docs: correct spelling of CHANGELOG
 
 ### Commit message with scope
 ```
-feat(lang): added polish language
+feat(lang): add polish language
 ```
 
 ### Commit message for a fix using an (optional) issue number.


### PR DESCRIPTION
While Conventional Commits itself does not specify verb tense for the description, it's common to use imperative, present tense describing what the commit, if applied, does, rather than past tense describing what was done. So adopt this convention in the example.

cf. https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#subject