### PR TITLE
fix: add spec compliant parser

### DIFF
--- a/spec/v1.0.0-beta.2.md
+++ b/spec/v1.0.0-beta.2.md
@@ -175,6 +175,7 @@ folks contributing to:
 ## Projects Using Conventional Commits
 
 * [yargs](https://github.com/yargs/yargs): everyone's favorite pirate themed command line argument parser.
+* [parse-commit-message](https://github.com/olstenlarck/parse-commit-message): Spec compliant parsing utility to get object like `{ header: { type, scope, subject }, body, footer }` from given commit message string.
 * [istanbuljs](https://github.com/istanbuljs/istanbuljs): a collection of open-source tools
   and libraries for adding test coverage to your JavaScript tests.
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.


### PR DESCRIPTION
It was in work for few months, but last night i released v2 of it. I'm using conventional commits for year or two, and thanks for that specification. I also have badge to the spec in most of my repos.

Let me know if something is not okey.
