### PR TITLE
docs: add Electron to list of projects

### DIFF
--- a/index.md
+++ b/index.md
@@ -169,6 +169,7 @@ The first draft of this specification has been written in collaboration with som
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
 * [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame): Optional supplemental user interface enhancing [Apereo uPortal](https://www.apereo.org/projects/uportal).
 * [massive.js](https://github.com/dmfay/massive-js): A data access library for Node and PostgreSQL.
+* [electron](https://github.com/electron/electron): Build cross-platform desktop apps with JavaScript, HTML, and CSS.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
The @electron project is now using Conventional Commits in many of its repos. We also built a bot to help make sure every PR we ship follows the CC spec: https://github.com/probot/semantic-pull-requests

We also use `semantic-release` all over the place: https://github.com/search?utf8=%E2%9C%93&q=%22npm+run+semantic-release%22+%40electron&type=Code